### PR TITLE
Add instruction for running on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:jessie
+
+WORKDIR /app
+
+# Install Zenaton
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y gawk \
+ && curl https://install.zenaton.com | sh \
+ && apt-get remove -y gawk \
+ && apt-get clean
+
+# Install dependencies
+ADD Gemfile* ./
+RUN bundle install
+
+ENTRYPOINT ["./start_zenaton"]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ This repository contains examples of workflows built with Zenaton. These example
 ## Installation
 Download this repo
 ```
-git clone https://github.com/zenaton/examples-ruby.git
-```
-and install dependencies
-```
-cd examples-ruby; bundle install
+git clone https://github.com/zenaton/examples-ruby.git; cd examples-ruby
 ```
 then add an .env file
 ```
@@ -16,6 +12,19 @@ cp .env.example .env
 ```
 and populate it with your application id and api token found [here](https://zenaton.com/app/api).
 
+### Running on Docker
+Simply run
+```
+docker-compose build; docker-compose up
+```
+
+You're all set!
+
+### Running Locally
+Install dependencies
+```
+bundle install
+```
 Then, you need to install a Zenaton worker
 ```
 curl https://install.zenaton.com | sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  app:
+    build: .
+    volumes:
+      - bundle:/usr/local/bundle
+      - .:/app
+    ports:
+      - "4001:4001"
+volumes:
+  bundle:

--- a/start_zenaton
+++ b/start_zenaton
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+zenaton start
+zenaton listen --env=.env --boot=boot.rb
+
+tail -f /dev/null


### PR DESCRIPTION
Currently blocked by the public release of the new version of the Zenaton worker with Ruby support.

This PR adds a docker image with the Zenaton worker installed to run these examples inside docker