### PR TITLE
Update docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,7 @@ WORKDIR /app
 # Install Zenaton
 RUN apt-get update \
  && apt-get upgrade -y \
- && apt-get install -y gawk \
  && curl https://install.zenaton.com | sh \
- && apt-get remove -y gawk \
  && apt-get clean
 
 # Install dependencies

--- a/recursive/display_task.rb
+++ b/recursive/display_task.rb
@@ -7,7 +7,7 @@ class DisplayTask < Zenaton::Interfaces::Task
   end
 
   def handle
-    print @counter
+    puts @counter
     sleep 1
   end
 end

--- a/recursive/relaunch_task.rb
+++ b/recursive/relaunch_task.rb
@@ -10,7 +10,7 @@ class RelaunchTask < Zenaton::Interfaces::Task
   def handle
     if @id < @max
       @id += 1
-      puts "\nIteration: #{@id}"
+      puts "Iteration: #{@id}"
       RecursiveWorkflow.new(@id, @max).dispatch
     end
   end

--- a/start_zenaton
+++ b/start_zenaton
@@ -2,10 +2,13 @@
 
 set -e
 
+# Make sure dependencies are installed
 bundle check || bundle install
 
+# Start zenaton worker
 zenaton start
 zenaton listen --env=.env --boot=boot.rb
 
+# Print zenaton output to stdout
 touch zenaton.out
 tail -f zenaton.out

--- a/start_zenaton
+++ b/start_zenaton
@@ -2,6 +2,8 @@
 
 set -e
 
+bundle check || bundle install
+
 zenaton start
 zenaton listen --env=.env --boot=boot.rb
 

--- a/start_zenaton
+++ b/start_zenaton
@@ -7,4 +7,5 @@ bundle check || bundle install
 zenaton start
 zenaton listen --env=.env --boot=boot.rb
 
-tail -f /dev/null
+touch zenaton.out
+tail -f zenaton.out


### PR DESCRIPTION
- gawk is no longer needed in the install script
- add check for up to date dependencies in entrypoint script
- change entrypoint script to tail the zenaton.out file to see the results
- change recursive display task to print new counters on a new line