### PR TITLE
Add unique IDs to event and wait_event

### DIFF
--- a/launch_event.rb
+++ b/launch_event.rb
@@ -1,9 +1,13 @@
+require 'securerandom'
+
 require './client'
 require './workflows/event_workflow'
 require './events/my_event'
 
-EventWorkflow.new('MyId').dispatch
+id = SecureRandom.hex(5)
+
+EventWorkflow.new(id).dispatch
 
 sleep 2
 
-EventWorkflow.where_id('MyId').send_event(MyEvent.new)
+EventWorkflow.where_id(id).send_event(MyEvent.new)

--- a/launch_wait_event.rb
+++ b/launch_wait_event.rb
@@ -1,9 +1,13 @@
+require 'securerandom'
+
 require './client'
 require './workflows/wait_event_workflow'
 require './events/my_event'
 
-WaitEventWorkflow.new('MyId').dispatch
+id = SecureRandom.hex(5)
+
+WaitEventWorkflow.new(id).dispatch
 
 sleep 2
 
-WaitEventWorkflow.where_id('MyId').send_event(MyEvent.new)
+WaitEventWorkflow.where_id(id).send_event(MyEvent.new)


### PR DESCRIPTION
PHP examples introduced unique IDs to identify these workflow. This
should keep the examples consistents across languages.